### PR TITLE
Hotwire updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'smarter_csv', '~> 1.9'
 gem 'sprockets-rails', '~> 3.4', '>= 3.4.2'
 
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
-gem 'stimulus-rails', '~> 1.2'
+gem 'stimulus-rails', '~> 1.3'
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem 'turbo-rails', '~> 1.5'

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'fog-aws', '~> 3.21'
 # font-awesome for iconography
 gem 'font-awesome-sass', '~> 6.4.2'
 
-gem "importmap-rails", "~> 1.2"
+gem 'importmap-rails', '~> 1.2', '>= 1.2.3'
 
 gem 'jquery-rails'
 

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'sprockets-rails', '~> 3.4', '>= 3.4.2'
 gem 'stimulus-rails', '~> 1.2'
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem 'turbo-rails', '~> 1.4'
+gem 'turbo-rails', '~> 1.5'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,8 +161,9 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    importmap-rails (1.2.1)
+    importmap-rails (1.2.3)
       actionpack (>= 6.0.0)
+      activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.6.0)
     irb (1.6.4)
@@ -380,7 +381,7 @@ DEPENDENCIES
   debug
   fog-aws (~> 3.21)
   font-awesome-sass (~> 6.4.2)
-  importmap-rails (~> 1.2)
+  importmap-rails (~> 1.2, >= 1.2.3)
   jbuilder (~> 2.11)
   jquery-rails
   listen (~> 3.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ GEM
     thor (1.2.2)
     tilt (2.0.9)
     timeout (0.4.0)
-    turbo-rails (1.4.0)
+    turbo-rails (1.5.0)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
@@ -405,7 +405,7 @@ DEPENDENCIES
   sprockets-rails (~> 3.4, >= 3.4.2)
   stimulus-rails (~> 1.2)
   terser (~> 1.1)
-  turbo-rails (~> 1.4)
+  turbo-rails (~> 1.5)
   tzinfo-data
   web-console (~> 4.2)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     ssrf_filter (1.1.2)
-    stimulus-rails (1.2.2)
+    stimulus-rails (1.3.0)
       railties (>= 6.0.0)
     terser (1.1.19)
       execjs (>= 0.3.0, < 3)
@@ -403,7 +403,7 @@ DEPENDENCIES
   simplecov (~> 0.22.0)
   smarter_csv (~> 1.9)
   sprockets-rails (~> 3.4, >= 3.4.2)
-  stimulus-rails (~> 1.2)
+  stimulus-rails (~> 1.3)
   terser (~> 1.1)
   turbo-rails (~> 1.5)
   tzinfo-data

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -10,5 +10,4 @@ $(".alert").fadeTo(2000, 500).slideUp(500, function(){
   if ($('#alerts-button').hasClass('unique-color-dark')) {
       $('#alerts-button').removeClass('unique-color-dark').addClass('rgba-lime-strong');
   }
-  $('button#alerts-button').effect("pulsate", {times:2}, 1000);
 <% end %>


### PR DESCRIPTION
This branch updates the Hotwire set of gems:

turbo-rails bumped to 1.5.0
stimulus-rails bumped to 1.30
importmap-rails bumped to 1.2.3

This branch also fixes a console error that was missed when we removed jquery-ui.