### PR TITLE
Canceled date fix

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -158,6 +158,7 @@ class Section < ApplicationRecord
     header = %w[section_id term department cross_list_group course_description section_number title credits level status enrollment_limit actual_enrollment cross_list_enrollment waitlist modality modality_description print_flag]
     # Parse spreadsheet.
     @updated_sections = 0
+    @uncanceled_sections = 0
     (first_row..last_real_row).each do |i|
       row = Hash[[header, spreadsheet.row(i)].transpose]
       # Hack to avoid blanks and headers when dealing with generated csv or xslt with disclaimer rows
@@ -192,6 +193,7 @@ class Section < ApplicationRecord
         if section.status != 'C'
           if section.status_changed? || !section.canceled_at.blank?
             section.canceled_at = nil
+            @uncanceled_sections += 1
             @import_report.report_item('Executing Import', 'Uncanceled Sections', "#{section.section_and_number} in #{section.term}")
           end
         end
@@ -215,6 +217,7 @@ class Section < ApplicationRecord
     @new_sections = created.size
     if touched.size > 0
       @import_report.report_item('Executing Import', 'Updated Sections', "<a href='/sections' class='dropdown-item'>#{@updated_sections} sections were updated during the import process. #{@new_sections} sections were created.</a>")
+      @import_report.report_item('Executing Import', 'Uncanceled Sections', "#{@uncanceled_sections} sections where uncanceled")
     else
       @import_report.report_item('Executing Import', 'Updated Sections', "<a href='/sections' class='dropdown-item'>The import file was empty.</a>")
     end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -189,6 +189,13 @@ class Section < ApplicationRecord
           end
         end
 
+        if section.status != 'C'
+          if section.status_changed? || !section.canceled_at.blank?
+            section.canceled_at = nil
+            @import_report.report_item('Executing Import', 'Uncanceled Sections', "#{section.section_and_number} in #{section.term}")
+          end
+        end
+
         # Save if changed, touch if unchanged
         if section.changed? || section.enrollments.last.new_record?
           section.save!

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -191,7 +191,7 @@ class Section < ApplicationRecord
         end
 
         if section.status != 'C'
-          if section.status_changed? || !section.canceled_at.blank?
+          if section.status_changed? || section.canceled_at.present?
             section.canceled_at = nil
             @uncanceled_sections += 1
             @import_report.report_item('Executing Import', 'Uncanceled Sections', "#{section.section_and_number} in #{section.term}")

--- a/test/models/section_test.rb
+++ b/test/models/section_test.rb
@@ -220,6 +220,17 @@ class SectionTest < ActiveSupport::TestCase
     assert_not_nil @section_three.canceled_at
   end
 
+  test 'import identifies uncanceled sections' do
+    assert_equal @section.status, 'CN'
+    @section.update(status: 'C', canceled_at: Time.now)
+    assert_equal @section.status, 'C'
+    assert_not_nil @section.canceled_at
+    Section.import(file_fixture('test_crse.csv'))
+    @section.reload
+    assert_equal @section.status, 'CN'
+    assert_nil @section.canceled_at
+  end
+
   test 'import creates an enrollment for a section' do
     assert_difference('@section.enrollments.count', + 1) do
       Section.import(file_fixture('test_crse.csv'))


### PR DESCRIPTION
This branch fixes a bug where if a section is canceled and then uncanceled, the `canceled_at` value is not cleared out. This branch adds a method to the import for sections with a status not equal to 'C' to check if the section status has changed during the import or if the `canceled_at` value is present. If a section does not have a status of 'C' and the status has changed or the `canceled_at` value is present, that value will be set to nil.

This branch also add reporting to the import emails to report on any uncanceled sections each day.

Prior to this change, we would see a canceled at value for a section that wasn't currently canceled if that section had been previously canceled and then restored.