### PR TITLE
Canceled date fix 2

### DIFF
--- a/app/helpers/sections_helper.rb
+++ b/app/helpers/sections_helper.rb
@@ -46,7 +46,7 @@ module SectionsHelper
   end
 
   def truthiness_indicator(value)
-    tag.i class: 'fa-solid fa-circle-check fa-large fa-xl' if value
+    tag.i class: 'fa-solid fa-circle-check fa-lg fa-xl' if value
   end
 
   def day_and_time(section)

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -191,7 +191,7 @@ class Section < ApplicationRecord
         end
 
         if section.status != 'C'
-          if section.status_changed? || section.canceled_at.present?
+          if section.status_changed? && section.canceled_at.present?
             section.canceled_at = nil
             @uncanceled_sections += 1
             @import_report.report_item('Executing Import', 'Uncanceled Sections', "#{section.section_and_number} in #{section.term}")


### PR DESCRIPTION
This branch follows up on the fix for the canceled date. It changes the `||` condition to an `&&` so that going forward, the check will require both that the status of a section has changed, doesn't equal `'C'` and has a `canceled_at` value set before setting `canceled_at` to nil. This should limit scope of the change to just sections that change from canceled to another status. This does assume that existing canceled section have the `canceled_at` value set.

While testing this, I also noticed that the font awesome icons for the marketing status were not working. This branch updates the font awesome class used to fix this.