### PR TITLE
Switch system test setup to use headless firefox.

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -65,4 +65,4 @@ jobs:
           PGUSER: postgres
           RAILS_ENV: test
         run: |
-          bin/rails test:all
+          PARALLEL_WORKERS=1 bin/rails test:all

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -65,4 +65,4 @@ jobs:
           PGUSER: postgres
           RAILS_ENV: test
         run: |
-          PARALLEL_WORKERS=1 bin/rails test:all
+          bin/rails test:all

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -176,6 +176,7 @@ Style/NumericLiterals:
     - 'test/models/setting_test.rb'
     - 'test/system/sections_test.rb'
     - 'test/test_helper.rb'
+    - test/application_system_test_case.rb
 Style/ClassAndModuleChildren:
   Exclude:
     - 'test/test_helper.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -176,7 +176,6 @@ Style/NumericLiterals:
     - 'test/models/setting_test.rb'
     - 'test/system/sections_test.rb'
     - 'test/test_helper.rb'
-    - test/application_system_test_case.rb
 Style/ClassAndModuleChildren:
   Exclude:
     - 'test/test_helper.rb'

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,13 +1,11 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [1920,1080]
+  Selenium::WebDriver.logger.ignore(:clear_local_storage, :clear_session_storage) # Silence deprecation warnings until upstream Capybara version is updated https://github.com/teamcapybara/capybara/issues/2779
 
-  # Added to ignore the browser options deprecation warning in rails 6.1 after upgrading to the
-  # latest webdrivers gem using Selenium 4. Rails 7 fixes these but the patch will not be
-  # backported. See https://github.com/rails/rails/pull/43503.
-  # Remove this line when upgrading to Rails 7.
-  Selenium::WebDriver.logger.ignore(:browser_options)
+  driven_by :selenium, using: :headless_firefox, screen_size: [1920, 1080]
+  # Switched to Firefox temporarily on 3/13/25. Since Chrome 133,
+  # we have been seeing race condition failures in our system specs.
 
   def login_as(user)
     visit cas_login_path

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -21,14 +21,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def logout
     visit logout_path
   end
-
-  setup do
-    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
-  end
-
-  teardown do
-    Setting.first&.destroy
-  end
 end
 
 module BootstrapSelectHelper

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,9 +7,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # Switched to Firefox temporarily on 3/13/25. Since Chrome 133,
   # we have been seeing race condition failures in our system specs.
 
-  setup do
-    @section = sections(:one)
-  end
 
   def login_as(user)
     visit cas_login_path

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,6 +7,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # Switched to Firefox temporarily on 3/13/25. Since Chrome 133,
   # we have been seeing race condition failures in our system specs.
 
+  setup do
+    @section = sections(:one)
+  end
+
   def login_as(user)
     visit cas_login_path
     fill_in 'username', with: user.username

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,7 +7,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # Switched to Firefox temporarily on 3/13/25. Since Chrome 133,
   # we have been seeing race condition failures in our system specs.
 
-
   def login_as(user)
     visit cas_login_path
     fill_in 'username', with: user.username

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,6 +7,14 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # Switched to Firefox temporarily on 3/13/25. Since Chrome 133,
   # we have been seeing race condition failures in our system specs.
 
+  setup do
+    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
+  end
+
+  teardown do
+    Setting.first.destroy
+  end
+
   def login_as(user)
     visit cas_login_path
     fill_in 'username', with: user.username

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,14 +7,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # Switched to Firefox temporarily on 3/13/25. Since Chrome 133,
   # we have been seeing race condition failures in our system specs.
 
-  setup do
-    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
-  end
-
-  teardown do
-    Setting.first.destroy
-  end
-
   def login_as(user)
     visit cas_login_path
     fill_in 'username', with: user.username

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -21,6 +21,14 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def logout
     visit logout_path
   end
+
+  setup do
+    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
+  end
+
+  teardown do
+    Setting.first&.destroy
+  end
 end
 
 module BootstrapSelectHelper

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class SessionsControllerTest < ActionDispatch::IntegrationTest
   setup do
+    @section = sections(:one)
     login_as(users(:three))
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class UsersControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:three)
+    @section = sections(:one)
   end
 
   teardown do

--- a/test/integration/email_delivery_config_test.rb
+++ b/test/integration/email_delivery_config_test.rb
@@ -10,6 +10,7 @@ class EmailDeliveryConfigTest < ActionDispatch::IntegrationTest
     Rake::Task.clear
     Sidekiq::Worker.clear_all
     Enrollchat::Application.load_tasks
+    @section = sections(:one)
     @settings = settings(:one)
   end
 

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -4,6 +4,7 @@ class NavigationTest < ActionDispatch::IntegrationTest
   setup do
     @admin = users(:one)
     @user = users(:two)
+    @section = sections(:one)
   end
 
   teardown do

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -18,6 +18,7 @@ class NavigationTest < ActionDispatch::IntegrationTest
   end
 
   test 'Users navigation link should not be available for non-admins' do
+    @section = sections(:two)
     login_as(@user)
     get sections_url
     assert_select 'li', text: 'Users', count: 0

--- a/test/integration/scheduler_reporting_emails_test.rb
+++ b/test/integration/scheduler_reporting_emails_test.rb
@@ -4,6 +4,7 @@ class SchedulerReportingEmailsTest < ActionDispatch::IntegrationTest
   include ActionMailer::TestHelper
 
   setup do
+    @section = sections(:one)
     Rake::Task.clear
     Enrollchat::Application.load_tasks
   end

--- a/test/integration/worker_reporting_emails_test.rb
+++ b/test/integration/worker_reporting_emails_test.rb
@@ -9,6 +9,7 @@ class WorkerReportingEmailsTest < ActionDispatch::IntegrationTest
     Rake::Task.clear
     Sidekiq::Worker.clear_all
     Enrollchat::Application.load_tasks
+    @section = sections(:one)
     @settings = settings(:one)
     @settings.update(email_delivery: 'on')
   end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class CommentTest < ActiveSupport::TestCase
   setup do
+    @section = sections(:one)
     @comment = comments(:one)
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   setup do
+    @section = sections(:one)
     @admin = users(:one)
     @user = users(:two)
   end

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -3,6 +3,7 @@ require "application_system_test_case"
 class SettingsTest < ApplicationSystemTestCase
   setup do
     login_as(users(:one))
+    @section = sections(:one)
     @setting = settings(:one)
   end
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -5,6 +5,7 @@ class UsersTest < ApplicationSystemTestCase
   setup do
     @admin = users(:one)
     @user = users(:three)
+    @section = sections(:one)
   end
 
   teardown do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,14 @@ require 'minitest/autorun'
 # silence Puma output in system tests
 Capybara.server = :puma, { Silent: true }
 
+setup do
+  Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
+end
+
+teardown do
+  Setting.first&.destroy
+end
+
 class ActiveSupport::TestCase
   # parallelize_setup do |worker|
   #   Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
@@ -26,14 +34,6 @@ class ActiveSupport::TestCase
   # parallelize threshold: 0 if ENV["CI"].present?
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
-
-  setup do
-    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
-  end
-
-  teardown do
-    Setting.first&.destroy
-  end
 end
 
 class ActionDispatch::IntegrationTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,7 +20,6 @@ class ActiveSupport::TestCase
 end
 
 class ActionDispatch::IntegrationTest
-
   setup do
     @section = sections(:one)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,7 +24,7 @@ class ActiveSupport::TestCase
   parallelize(workers: 1)
 
   parallelize threshold: 0 if ENV["CI"].present?
-
+  
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,9 +21,8 @@ class ActiveSupport::TestCase
   #   SimpleCov.result
   # end
   # Run tests in parallel with specified workers
-  parallelize(workers: 1)
-
-  parallelize threshold: 0 if ENV["CI"].present?
+  parallelize(workers: 1, threshold: 0)
+  
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,7 +24,7 @@ class ActiveSupport::TestCase
   parallelize(workers: 1)
 
   parallelize threshold: 0 if ENV["CI"].present?
-  
+
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,7 @@ class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
   parallelize(workers: 1)
 
-  # parallelize threshold: 0 if ENV["CI"].present?
+  parallelize threshold: 0 if ENV["CI"].present?
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,14 +27,6 @@ class ActiveSupport::TestCase
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
-
-  setup do
-    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
-  end
-
-  teardown do
-    Setting.first&.destroy
-  end
 end
 
 class ActionDispatch::IntegrationTest
@@ -56,12 +48,4 @@ class ActionDispatch::IntegrationTest
   ENV['TERM_TWO_END'] = '1'
   ENV['CAMPUS_CODE_ONE'] = 'VA'
   ENV['CAMPUS_LABEL_ONE'] = 'Virginia Campus'
-
-  setup do
-    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
-  end
-
-  teardown do
-    Setting.first&.destroy
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,14 +10,6 @@ require 'minitest/autorun'
 # silence Puma output in system tests
 Capybara.server = :puma, { Silent: true }
 
-setup do
-  Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
-end
-
-teardown do
-  Setting.first&.destroy
-end
-
 class ActiveSupport::TestCase
   # parallelize_setup do |worker|
   #   Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
@@ -34,6 +26,14 @@ class ActiveSupport::TestCase
   # parallelize threshold: 0 if ENV["CI"].present?
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
+
+  setup do
+    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
+  end
+
+  teardown do
+    Setting.first&.destroy
+  end
 end
 
 class ActionDispatch::IntegrationTest
@@ -55,4 +55,12 @@ class ActionDispatch::IntegrationTest
   ENV['TERM_TWO_END'] = '1'
   ENV['CAMPUS_CODE_ONE'] = 'VA'
   ENV['CAMPUS_LABEL_ONE'] = 'Virginia Campus'
+
+  setup do
+    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
+  end
+
+  teardown do
+    Setting.first&.destroy
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,18 @@ class ActiveSupport::TestCase
 
   # parallelize threshold: 0 if ENV["CI"].present?
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+  setup do
+    unless Setting.first
+      Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
+    end
+  end
+
+  teardown do
+    if Setting.first
+      Setting.first.destroy
+    end
+  end
+
   fixtures :all
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,7 +21,9 @@ class ActiveSupport::TestCase
   #   SimpleCov.result
   # end
   # Run tests in parallel with specified workers
-  parallelize(workers: 1, threshold: 0)
+  # parallelize(workers: :number_of_processors)
+
+  # parallelize threshold: 0 if ENV["CI"].present?
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,14 +13,6 @@ Capybara.server = :puma, { Silent: true }
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
-
-  setup do
-    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
-  end
-
-  teardown do
-    Setting.first&.destroy
-  end
 end
 
 class ActionDispatch::IntegrationTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,16 +13,9 @@ Capybara.server = :puma, { Silent: true }
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
-
-  setup do
-    @section = sections(:one)
-  end
 end
 
 class ActionDispatch::IntegrationTest
-  setup do
-    @section = sections(:one)
-  end
   def login_as(user)
     post login_path, params: { username: user.username, password: 'any password' }
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,19 +11,19 @@ require 'minitest/autorun'
 Capybara.server = :puma, { Silent: true }
 
 class ActiveSupport::TestCase
-  # parallelize_setup do |worker|
-  #   Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
-  #   SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
-  # end
-  #
-  # parallelize_teardown do
-  #   Setting.first.destroy
-  #   SimpleCov.result
-  # end
-  # Run tests in parallel with specified workers
-  # parallelize(workers: :number_of_processors)
+  parallelize_setup do |worker|
+    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
+    SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
+  end
 
-  # parallelize threshold: 0 if ENV["CI"].present?
+  parallelize_teardown do
+    Setting.first.destroy
+    SimpleCov.result
+  end
+  # Run tests in parallel with specified workers
+  parallelize(workers: 1)
+
+  parallelize threshold: 0 if ENV["CI"].present?
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,19 +11,19 @@ require 'minitest/autorun'
 Capybara.server = :puma, { Silent: true }
 
 class ActiveSupport::TestCase
-  parallelize_setup do |worker|
-    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
-    SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
-  end
-
-  parallelize_teardown do
-    Setting.first.destroy
-    SimpleCov.result
-  end
+  # parallelize_setup do |worker|
+  #   Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
+  #   SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
+  # end
+  #
+  # parallelize_teardown do
+  #   Setting.first.destroy
+  #   SimpleCov.result
+  # end
   # Run tests in parallel with specified workers
-  parallelize(workers: :number_of_processors)
+  # parallelize(workers: :number_of_processors)
 
-  parallelize threshold: 0 if ENV["CI"].present?
+  # parallelize threshold: 0 if ENV["CI"].present?
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,13 +27,13 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
-  # setup do
-  #   Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
-  # end
-  #
-  # teardown do
-  #   Setting.first&.destroy
-  # end
+  setup do
+    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
+  end
+
+  teardown do
+    Setting.first&.destroy
+  end
 end
 
 class ActionDispatch::IntegrationTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,7 @@ class ActiveSupport::TestCase
   # end
   # Run tests in parallel with specified workers
   parallelize(workers: 1, threshold: 0)
-  
+
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,21 +23,17 @@ class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
   # parallelize(workers: :number_of_processors)
 
-  # parallelize threshold: 0 if ENV["CI"].present?
+  parallelize threshold: 0 if ENV["CI"].present?
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  setup do
-    unless Setting.first
-      Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
-    end
-  end
-
-  teardown do
-    if Setting.first
-      Setting.first.destroy
-    end
-  end
-
   fixtures :all
+
+  # setup do
+  #   Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
+  # end
+  #
+  # teardown do
+  #   Setting.first&.destroy
+  # end
 end
 
 class ActionDispatch::IntegrationTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,9 +27,24 @@ class ActiveSupport::TestCase
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
+
+  setup do
+    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
+  end
+
+  teardown do
+    Setting.first.destroy
+  end
 end
 
 class ActionDispatch::IntegrationTest
+  setup do
+    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
+  end
+
+  teardown do
+    Setting.first.destroy
+  end
   def login_as(user)
     post login_path, params: { username: user.username, password: 'any password' }
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,9 +13,17 @@ Capybara.server = :puma, { Silent: true }
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
+
+  setup do
+    @section = sections(:one)
+  end
 end
 
 class ActionDispatch::IntegrationTest
+
+  setup do
+    @section = sections(:one)
+  end
   def login_as(user)
     post login_path, params: { username: user.username, password: 'any password' }
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,40 +11,19 @@ require 'minitest/autorun'
 Capybara.server = :puma, { Silent: true }
 
 class ActiveSupport::TestCase
-  parallelize_setup do |worker|
-    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
-    SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
-  end
-
-  parallelize_teardown do
-    Setting.first.destroy
-    SimpleCov.result
-  end
-  # Run tests in parallel with specified workers
-  parallelize(workers: 1)
-
-  parallelize threshold: 0 if ENV["CI"].present?
-
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
   setup do
-    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
+    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled') unless Setting.first
   end
 
   teardown do
-    Setting.first.destroy
+    Setting.first&.destroy
   end
 end
 
 class ActionDispatch::IntegrationTest
-  setup do
-    Setting.create!(current_term: 201810, singleton_guard: 0, undergraduate_enrollment_threshold: 12, graduate_enrollment_threshold: 10, email_delivery: 'scheduled')
-  end
-
-  teardown do
-    Setting.first.destroy
-  end
   def login_as(user)
     post login_path, params: { username: user.username, password: 'any password' }
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,9 +21,9 @@ class ActiveSupport::TestCase
   #   SimpleCov.result
   # end
   # Run tests in parallel with specified workers
-  # parallelize(workers: :number_of_processors)
+  parallelize(workers: 1)
 
-  parallelize threshold: 0 if ENV["CI"].present?
+  # parallelize threshold: 0 if ENV["CI"].present?
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 


### PR DESCRIPTION
Since Chrome 133, we have been seeing inconsistent spec failure that appear to be caused by race conditions. This branch makes some temporary fixes to get our CI up and running again. Long term, we should probably switch to [Cuprite](https://github.com/rubycdp/cuprite).