### PR TITLE
Bootstrap Form Multi Selector Directions

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -85,7 +85,9 @@
             <div class="col-md-6">
             <%= f.select :departments, Section.department_list, {include_blank: false}, {multiple: 'true', class: 'form-select'} %>
             <small id="passwordHelpBlock" class="form-text text-muted">
-                Select one or more departments if you wish to limit your alerts and emails to comments that are relevant to you.
+                Select one or more departments if you wish to limit your alerts and emails to comments that are relevant to you. <br>
+                Mac users: Hold the <kbd>Command</kbd> key and click to select multiple options. <br>
+                Windows users: Hold the <kbd>Ctrl</kbd> (Control) key and click to select multiple options.
             </small>
             </div>
         </div>


### PR DESCRIPTION
After upgrading to the latest version of Bootstrap, we removed the dependency on bootstrap-select and replaced it with Bootstrap’s built-in multi-select form control. This branch adds usage instructions for the new native multi-select element.

Before:

<img width="1487" height="514" alt="beforeselector" src="https://github.com/user-attachments/assets/3d60e9d9-385d-4690-8799-31f9793553d2" />

After:

<img width="1487" height="514" alt="afterselector" src="https://github.com/user-attachments/assets/01f0704a-3785-4f45-80d4-7518c8017c06" />
